### PR TITLE
BootStrap3から4へのバージョンアップ レイアウト修正 レスポンシブ対応

### DIFF
--- a/resources/views/common/errors.blade.php
+++ b/resources/views/common/errors.blade.php
@@ -2,8 +2,6 @@
 
 @if(count($errors)>0)
     {{-- Form Error List --}}
-    {{-- smallを追加 タブレット以下では文字列が小さくなる --}}
-    {{-- pb-0を追加 アラート部分がデカかった為 --}}
     <div class="alert alert-danger small pb-0">
         <strong>おや？　何かがおかしいようです！</strong>
         

--- a/resources/views/common/errors.blade.php
+++ b/resources/views/common/errors.blade.php
@@ -2,7 +2,9 @@
 
 @if(count($errors)>0)
     {{-- Form Error List --}}
-    <div class="alert alert-danger">
+    {{-- smallを追加 タブレット以下では文字列が小さくなる --}}
+    {{-- pb-0を追加 アラート部分がデカかった為 --}}
+    <div class="alert alert-danger small pb-0">
         <strong>おや？　何かがおかしいようです！</strong>
         
         <br><br>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>Laravel Quickstart - Basic</title>
     {{-- Fonts --}}
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/css/font-awesome.min.css"
     type="text/css">
     {{-- CSS bootstrap4 --}}
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
 
 </head>
 <body>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,14 +5,24 @@
     {{-- Fonts --}}
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/css/font-awesome.min.css"
     type="text/css">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">
+    {{-- CSS bootstrap4 --}}
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/resources/css/app.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
 </head>
 <body>
-    <nav class="navbar navbar-default">
+    {{-- navbar-defaultからnavbar-lightに 文字を黒に--}}
+    {{-- navbar-expand-lgを追加 狭い画面の際折りたたまれて表示--}}
+    {{-- bg-lightを追加 バーの背景色が灰色に--}}
+    {{-- borderを追加 ナビゲーションバーに枠線が追加 --}}
+    <nav class="navbar navbar-expand-lg navbar-light bg-light border text-muted">
         <div class="container">
             {{-- navbar --}}
             <div class="navbar-header">
-                <a class="navbar-brand" href="{{ url('/') }}">
+                {{-- p-0を追加 ナビゲーションバーの高さを調整 --}}
+                {{-- text-mutedを追加 文字列を灰色に --}}
+                <a class="navbar-brand p-0 text-muted" href="{{ url('/') }}">
                 Task List
                 </a>
             </div>
@@ -21,6 +31,6 @@
     {{--　子が自由に書ける場所 --}}
     @yield('content')
     {{-- JavaScripts --}}
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -11,23 +11,18 @@
 
 </head>
 <body>
-    {{-- navbar-defaultからnavbar-lightに 文字を黒に--}}
-    {{-- navbar-expand-lgを追加 狭い画面の際折りたたまれて表示--}}
-    {{-- bg-lightを追加 バーの背景色が灰色に--}}
-    {{-- borderを追加 ナビゲーションバーに枠線が追加 --}}
+
     <nav class="navbar navbar-expand-lg navbar-light bg-light border text-muted">
         <div class="container">
             {{-- navbar --}}
             <div class="navbar-header">
-                {{-- p-0を追加 ナビゲーションバーの高さを調整 --}}
-                {{-- text-mutedを追加 文字列を灰色に --}}
                 <a class="navbar-brand p-0 text-muted" href="{{ url('/') }}">
                 Task List
                 </a>
             </div>
         </div>
     </nav>
-    {{--　子が自由に書ける場所 --}}
+
     @yield('content')
     {{-- JavaScripts --}}
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.bundle.min.js"></script>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -7,7 +7,6 @@
     type="text/css">
     {{-- CSS bootstrap4 --}}
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <link rel="stylesheet" href="/resources/css/app.css">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
 </head>

--- a/resources/views/tasks.blade.php
+++ b/resources/views/tasks.blade.php
@@ -1,32 +1,54 @@
 @extends('layouts.app')
 @section('content')
-    <div class="container">
-        <div class="col-sm-offset-2 col-sm-8">
-            <div class="panel panel-default">
-                <div class="panel-heading">
+    {{-- mt-4を追加 ナビゲーションバーとの間に余白を追加 --}}
+
+    <div class="container mt-4">
+        {{-- mx-autoを追加 テーブルが中央に --}}
+        <div class="col-sm-offset-2 col-sm-8 mx-auto">
+            {{-- panel-default削除。廃止、代替なし --}}
+            {{-- panelをcardに変更 --}}
+            {{-- borderを追加 テーブルに枠線が追加 --}}
+            {{-- roundedを追加 パネルの角全てが丸みを帯びる --}}
+            <div class="card border rounded">
+                {{-- panel-headingはcard-headerに --}}
+                {{-- pt-2 pb-2を追加 NewTaskタイトル部分の高さの調整--}}
+                <div class="card-header pt-2 pb-2">
                 New Task
                 </div>
 
-                <div class="panel-body">
+                {{-- panel-bodyからcard-bodyへ --}}
+                <div class="card-body">
                     {{-- Display Validation Errors --}}
                     {{-- resources/views/common/errors.blade.phpをロード --}}
                     @include('common.errors')
 
                     {{-- New Task Form --}}
-                    <form action="{{ url('task') }}" method="POST" class="form-horizontal">
+                    {{-- form-horizontalを削除。廃止 --}}
+                    <form action="{{ url('task') }}" method="POST">
                         {{ csrf_field() }}
                         {{-- Task Name --}}
-                        <div class="form-group">
-                            <label for="task-name" class="col-sm-3 control-label">Task</label>
-                            <div class="col-sm-6">
-                                <input type="text" name="name" id="task-name" class="form-control">
+                        {{-- rowを追加 Taskとフォームが横並びに--}}
+                        <div class="form-group row mt-0">
+                            {{-- col-sm-3からcol-md-3へ ここの数値をいじればフォームの位置を調整できる
+                            control-labelからcol-form-labelへ 
+                            text-sm-leftを追加 576px以下の際、文字が左に移動
+                            text-md-rightを追加 タブレット以上の際、文字が右に移動
+                            font-weight-boldを追加 Tasksの文字が太文字
+                            --}}
+                            <label for="task-name" class="col-md-3 text-md-right text-sm-left col-form-label font-weight-bold">Task</label>
+                            {{-- col-sm-6をcol-md-6へ ここの数値をいじればフォーム欄の長さがが変わる--}}
+                            <div class="col-md-6">
+                                {{-- borderを追加 AddTaskボタンと枠線の色を合わせる為 --}}
+                                <input type="text" name="name" id="task-name" class="form-control border">
                             </div>
                         </div>
 
                         {{-- Add Task Button --}}
-                        <div class="form-group">
-                            <div class="col-sm-offset-3 col-sm-6">
-                                <button type="submit" class="btn btn-default">
+                        {{-- rowを追加 --}}
+                        <div class="form-group row ">
+                            <div class="rounded col-md-3 offset-md-3">
+                                {{-- text-nowrapを追加 テキストを折り返さないように固定 --}}
+                                <button type="submit" class="btn btn-default border text-nowrap">
                                     <i class="fa fa-btn fa-plus"></i>Add Task
                                 </button>
                             </div>
@@ -36,17 +58,23 @@
 
                 {{-- TODO: Current Tasks --}}
                 @if(count($tasks) > 0)
-                <div class="panel panel-default">
-                    <div class="panel-heading">
+                {{-- panel-defaultを削除 --}}
+                <div class="card border rounded mb-4">
+                    {{-- card-headerを追加 タイトルがちゃんと分かれるようになった --}}
+                    {{-- pt-2 pb-2を追加 現在のタスクタイトル部分の高さの調整 --}}
+                    <div class="card-header rounded-top pt-2 pb-2">
                         現在のタスク
                     </div>
 
-                    <div class="panel-body">
+                    {{-- pr-3,pl-3を追加 --}}
+                    <div class="card-body pr-3 pl-3">
                         <table class="table table-striped task-table">
                             {{-- テーブルヘッダ --}}
                             <thead>
-                                <th>Task</th>
-                                <th>&nbsp;</th>
+                                {{-- border-top-0を追加 table上部の枠線を消すため --}}
+                                {{-- pt-4を追加 テーブルの位置を少し下に下げる為 --}}
+                                <th class="border-top-0 pt-2">Task</th>
+                                <th class="border-top-0 pt-2">&nbsp;</th>
                             </thead>
 
                             {{-- テーブル本体 --}}
@@ -54,17 +82,19 @@
                                 @foreach($tasks as $task)
                                     <tr>
                                         {{-- タスク名 --}}
-                                        <td class="table-text">
+                                        {{-- text-darkを追加 少しだけフォントカラーを薄い黒に --}}
+                                        <td class="table-text pt-1 pb-1 text-dark">
                                             <div>{{ $task->name }}</div>
                                         </td>
                                         {{-- Delete Button --}}
-                                        <td>
+                                        {{-- align-middleを追加　DELETEボタンを中央位置に来るように --}}
+                                        <td  class="pt-1 pb-1 align-middle">
                                             {{-- リクエスト先をtaskのidを入れて指定してる --}}
                                             <form action="{{ url('task/' .$task->id) }}" method="POST">
                                             @csrf
                                             @method('DELETE')
-
-                                            <button type="submit" class="btn btn-danger">
+                                            {{-- text-nowrapを追加 スマホ画面でマークと文字列が改行されないように --}}
+                                            <button type="submit" class="btn btn-danger text-nowrap">
                                                 <i class="fa fa-trash"></i>Delete
                                             </button>
                                         </form>

--- a/resources/views/tasks.blade.php
+++ b/resources/views/tasks.blade.php
@@ -44,8 +44,7 @@
                         </div>
 
                         {{-- Add Task Button --}}
-                        {{-- rowを追加 --}}
-                        <div class="form-group row ">
+                        <div class="form-group">
                             <div class="rounded col-md-3 offset-md-3">
                                 {{-- text-nowrapを追加 テキストを折り返さないように固定 --}}
                                 <button type="submit" class="btn btn-default border text-nowrap">

--- a/resources/views/tasks.blade.php
+++ b/resources/views/tasks.blade.php
@@ -1,44 +1,25 @@
 @extends('layouts.app')
 @section('content')
-    {{-- mt-4を追加 ナビゲーションバーとの間に余白を追加 --}}
+
 
     <div class="container mt-4">
-        {{-- mx-autoを追加 テーブルが中央に --}}
         <div class="col-sm-offset-2 col-sm-8 mx-auto">
-            {{-- panel-default削除。廃止、代替なし --}}
-            {{-- panelをcardに変更 --}}
-            {{-- borderを追加 テーブルに枠線が追加 --}}
-            {{-- roundedを追加 パネルの角全てが丸みを帯びる --}}
             <div class="card border rounded">
-                {{-- panel-headingはcard-headerに --}}
-                {{-- pt-2 pb-2を追加 NewTaskタイトル部分の高さの調整--}}
                 <div class="card-header pt-2 pb-2">
                 New Task
                 </div>
 
-                {{-- panel-bodyからcard-bodyへ --}}
                 <div class="card-body">
                     {{-- Display Validation Errors --}}
-                    {{-- resources/views/common/errors.blade.phpをロード --}}
                     @include('common.errors')
 
                     {{-- New Task Form --}}
-                    {{-- form-horizontalを削除。廃止 --}}
                     <form action="{{ url('task') }}" method="POST">
                         {{ csrf_field() }}
                         {{-- Task Name --}}
-                        {{-- rowを追加 Taskとフォームが横並びに--}}
                         <div class="form-group row mt-0 mx-0">
-                            {{-- col-sm-3からcol-md-3へ ここの数値をいじればフォームの位置を調整できる
-                            control-labelからcol-form-labelへ 
-                            text-sm-leftを追加 576px以下の際、文字が左に移動
-                            text-md-rightを追加 タブレット以上の際、文字が右に移動
-                            font-weight-boldを追加 Tasksの文字が太文字
-                            --}}
                             <label for="task-name" class="col-md-3 text-md-right text-sm-left col-form-label font-weight-bold">Task</label>
-                            {{-- col-sm-6をcol-md-6へ ここの数値をいじればフォーム欄の長さがが変わる--}}
                             <div class="col-md-6">
-                                {{-- borderを追加 AddTaskボタンと枠線の色を合わせる為 --}}
                                 <input type="text" name="name" id="task-name" class="form-control border">
                             </div>
                         </div>
@@ -46,7 +27,6 @@
                         {{-- Add Task Button --}}
                         <div class="form-group">
                             <div class="rounded col-md-3 offset-md-3">
-                                {{-- text-nowrapを追加 テキストを折り返さないように固定 --}}
                                 <button type="submit" class="btn btn-default border text-nowrap">
                                     <i class="fa fa-btn fa-plus"></i>Add Task
                                 </button>
@@ -57,21 +37,15 @@
 
                 {{-- TODO: Current Tasks --}}
                 @if(count($tasks) > 0)
-                {{-- panel-defaultを削除 --}}
                 <div class="card border rounded mb-4">
-                    {{-- card-headerを追加 タイトルがちゃんと分かれるようになった --}}
-                    {{-- pt-2 pb-2を追加 現在のタスクタイトル部分の高さの調整 --}}
                     <div class="card-header rounded-top pt-2 pb-2">
                         現在のタスク
                     </div>
 
-                    {{-- pr-3,pl-3を追加 --}}
                     <div class="card-body pr-3 pl-3">
                         <table class="table table-striped task-table">
                             {{-- テーブルヘッダ --}}
                             <thead>
-                                {{-- border-top-0を追加 table上部の枠線を消すため --}}
-                                {{-- pt-4を追加 テーブルの位置を少し下に下げる為 --}}
                                 <th class="border-top-0 pt-2">Task</th>
                                 <th class="border-top-0 pt-2">&nbsp;</th>
                             </thead>
@@ -81,18 +55,14 @@
                                 @foreach($tasks as $task)
                                     <tr>
                                         {{-- タスク名 --}}
-                                        {{-- text-darkを追加 少しだけフォントカラーを薄い黒に --}}
                                         <td class="table-text pt-1 pb-1 text-dark">
                                             <div>{{ $task->name }}</div>
                                         </td>
                                         {{-- Delete Button --}}
-                                        {{-- align-middleを追加　DELETEボタンを中央位置に来るように --}}
                                         <td  class="pt-1 pb-1 align-middle">
-                                            {{-- リクエスト先をtaskのidを入れて指定してる --}}
                                             <form action="{{ url('task/' .$task->id) }}" method="POST">
                                             @csrf
                                             @method('DELETE')
-                                            {{-- text-nowrapを追加 スマホ画面でマークと文字列が改行されないように --}}
                                             <button type="submit" class="btn btn-danger text-nowrap">
                                                 <i class="fa fa-trash"></i>Delete
                                             </button>

--- a/resources/views/tasks.blade.php
+++ b/resources/views/tasks.blade.php
@@ -28,7 +28,7 @@
                         {{ csrf_field() }}
                         {{-- Task Name --}}
                         {{-- rowを追加 Taskとフォームが横並びに--}}
-                        <div class="form-group row mt-0">
+                        <div class="form-group row mt-0 mx-0">
                             {{-- col-sm-3からcol-md-3へ ここの数値をいじればフォームの位置を調整できる
                             control-labelからcol-form-labelへ 
                             text-sm-leftを追加 576px以下の際、文字が左に移動

--- a/resources/views/tasks.blade.php
+++ b/resources/views/tasks.blade.php
@@ -5,7 +5,7 @@
     <div class="container mt-4">
         <div class="col-sm-offset-2 col-sm-8 mx-auto">
             <div class="card border rounded">
-                <div class="card-header pt-2 pb-2">
+                <div class="card-header py-2">
                 New Task
                 </div>
 


### PR DESCRIPTION
研修課題で作成したタスク管理サイトのBootstrapをバージョンアップしました。

変更した箇所
  -Bootstrap3からBootstrap4へのバージョンアップ
  -バージョンアップに伴って崩れたレイアウトの修正
  -レスポンシブ対応

変更前のブラウザ スクリーンショット
<img width="1440" alt="スクリーンショット 2023-12-15 16 15 04" src="https://github.com/TanakaTanakaKK/quickstart-laravel/assets/153486570/f3a6276d-f71b-4276-9ccc-3b9f1ab6dd78">

変更後のブラウザ スクリーンショット
<img width="1440" alt="スクリーンショット 2023-12-15 16 15 37" src="https://github.com/TanakaTanakaKK/quickstart-laravel/assets/153486570/1b60df8a-a3f0-4a5c-a957-57eab00ac22a">

変更後のiPhoneSE スクリーンショット
<img width="1440" alt="スクリーンショット 2023-12-15 16 58 27" src="https://github.com/TanakaTanakaKK/quickstart-laravel/assets/153486570/74510e33-edcd-4812-938b-3b06bf0cdb3f">

変更後のiPad Pro スクリーンショット
<img width="1440" alt="スクリーンショット 2023-12-15 17 01 05" src="https://github.com/TanakaTanakaKK/quickstart-laravel/assets/153486570/a1bea79c-215b-47ae-8df1-2653f6ed7ce3">
