### PR TITLE
タスクのCSV出力、ソート、ページネーション、期限での切替機能の追加

### DIFF
--- a/app/Http/Controllers/AuthenticationController.php
+++ b/app/Http/Controllers/AuthenticationController.php
@@ -79,7 +79,7 @@ class AuthenticationController extends Controller
     public function complete(Request $request)
     {
         if(is_null($request->session()->get('is_sent_authentication_mail'))){
-            return to_route('tasks.index');
+            return to_route('task.index');
         }
 
         return view('authentication.complete', [

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -148,7 +148,6 @@ class TaskController extends Controller
 
     public function edit(Request $request, Task $task)
     {
-        dd(auth()->user());
         if(!Gate::allows('isAdmin') && !auth()->user()->can('update', $task)){
             return to_route('task.index')->withErrors(['access_error' => '不正なアクセスです。']);
         }

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -224,7 +224,7 @@ class TaskController extends Controller
 
         $response_headers = [
             'Content-type' => 'text/csv',
-            'Content-Disposition' => 'attachment; filename=sample.csv',
+            'Content-Disposition' => 'attachment; filename=task.csv',
             'Pragma' => 'no-cache',
             'Expires' => 0,
         ];

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -2,10 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Enums\{
-    CsvTaskColumn,
-    TaskStatus
-};
+use App\Enums\TaskStatus;
 use App\Models\{
     Task,
 };
@@ -33,8 +30,15 @@ class TaskController extends Controller
         })->when(!Gate::allows('isAdmin'), function($query) {
             return $query->where('user_id', auth()->id());
             
-        })->orderBy('expired_at', 'asc')
-        ->get();
+        })->when(!is_null($request->query('expired')), function($query) use ($request){
+            $request->session()->put('is_change_for_expired', true);
+            return $query->where('expired_at', '<', now());
+        })->when(!is_null($request->query('active')), function($query) use ($request){
+            $request->session()->put('is_change_for_expired', false);
+            return $query->where('expired_at', '>', now());
+        })
+        ->sortable()
+        ->paginate(10);
 
         if(!is_null($request->session()->get('task_message'))){
             return view('task.index', [
@@ -140,11 +144,11 @@ class TaskController extends Controller
         return view('task.show', [
             'task' => $task->load('taskComments.user'),
         ]);
-        
     }
 
     public function edit(Request $request, Task $task)
     {
+        dd(auth()->user());
         if(!Gate::allows('isAdmin') && !auth()->user()->can('update', $task)){
             return to_route('task.index')->withErrors(['access_error' => '不正なアクセスです。']);
         }
@@ -209,6 +213,58 @@ class TaskController extends Controller
         }
         
         return to_route('task.show', $task);
+    }
+
+    public function exportCsv(Request $request)
+    {
+        $tasks = Task::when(!Gate::allows('isAdmin'), function($query) {
+            return $query->where('user_id', auth()->id());
+            
+        })->get();
+
+        $response_headers = [
+            'Content-type' => 'text/csv',
+            'Content-Disposition' => 'attachment; filename=sample.csv',
+            'Pragma' => 'no-cache',
+            'Expires' => 0,
+        ];
+
+        $callback = function() use ($tasks) {
+            
+            $resource = fopen('php://output', 'w');
+            
+            if(Gate::allows('isAdmin')){
+                $tasks->load('user');
+
+                fputcsv($resource, ['ユーザー名', 'タスク名', '内容', '期限', 'ステータス']);
+
+                foreach($tasks as $task) {
+                    $task->toArray();
+                    fputcsv($resource, [
+                        $task->user->name,
+                        $task->name, 
+                        $task->detail, 
+                        $task->expired_at,
+                        TaskStatus::getDescription($task->status)
+                    ]);
+                }
+            }else{
+                fputcsv($resource, ['タスク名', '内容', '期限', 'ステータス']);
+
+                foreach($tasks as $task) {
+                    $task->toArray();
+                    fputcsv($resource, [
+                        $task->name, 
+                        $task->detail, 
+                        $task->expired_at,
+                        TaskStatus::getDescription($task->status)
+                    ]);
+                }
+            }
+            fclose($resource);
+        };
+
+        return response()->stream($callback, 200, $response_headers);
     }
 
     public function destroy(Request $request, Task $task)

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -4,10 +4,14 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Kyslik\ColumnSortable\Sortable;
 
 class Task extends Model
 {
     use HasFactory;
+    use Sortable;
+
+    public $sortable = ['name','user_id','expired_at','status'];
 
     protected $fillable = [
         'name',

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "php": "^8.1",
         "bensampo/laravel-enum": "^6.7",
         "guzzlehttp/guzzle": "^7.2",
+        "kyslik/column-sortable": "^6.5",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",
         "laravel/tinker": "^2.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9409dfb293056e43a8140e632e14f08c",
+    "content-hash": "7725b90b058d512cae7c5b03b062b94c",
     "packages": [
         {
             "name": "bensampo/laravel-enum",
@@ -1280,6 +1280,67 @@
                 }
             ],
             "time": "2023-12-03T19:50:20+00:00"
+        },
+        {
+            "name": "kyslik/column-sortable",
+            "version": "6.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Kyslik/column-sortable.git",
+                "reference": "80a7f053cf8e457be06d5fe59371f1b2b5cd8d03"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Kyslik/column-sortable/zipball/80a7f053cf8e457be06d5fe59371f1b2b5cd8d03",
+                "reference": "80a7f053cf8e457be06d5fe59371f1b2b5cd8d03",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "5.8.*|^6.0|^7.0|^8.0|^9.0|^10.0",
+                "illuminate/support": "5.8.*|^6.0|^7.0|^8.0|^9.0|^10.0",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^5.0|^7.0|^8.0",
+                "phpunit/phpunit": "^8.5|^9.5.10"
+            },
+            "type": "package",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Kyslik\\ColumnSortable\\ColumnSortableServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Kyslik\\ColumnSortable\\": "src/ColumnSortable/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Martin Kiesel",
+                    "email": "martin.kiesel@gmail.com",
+                    "role": "Developer and maintainer"
+                }
+            ],
+            "description": "Package for handling column sorting in Laravel 6.x",
+            "keywords": [
+                "column",
+                "laravel",
+                "sort",
+                "sortable",
+                "sorting"
+            ],
+            "support": {
+                "issues": "https://github.com/Kyslik/column-sortable/issues",
+                "source": "https://github.com/Kyslik/column-sortable/tree/6.5.0"
+            },
+            "time": "2023-02-17T09:46:34+00:00"
         },
         {
             "name": "laminas/laminas-code",

--- a/resources/views/common/info.blade.php
+++ b/resources/views/common/info.blade.php
@@ -1,3 +1,4 @@
+
 @if(isset($is_succeeded))
     <div class="alert alert-success small pb-0">
         <strong>お知らせ</strong>

--- a/resources/views/common/info.blade.php
+++ b/resources/views/common/info.blade.php
@@ -1,4 +1,3 @@
-
 @if(isset($is_succeeded))
     <div class="alert alert-success small pb-0">
         <strong>お知らせ</strong>

--- a/resources/views/task/index.blade.php
+++ b/resources/views/task/index.blade.php
@@ -25,7 +25,7 @@
                         </div>
                     </form>
                 </div>
-                    <div class="card-body px-3 py-0 overflow-auto text-right">
+                    <div class="card-body px-2 py-0 overflow-auto text-right">
                         <div class="mx-2">
                                     <form action="{{ route('task.index') }}" method="GET">
                                         @if(is_null(session('is_change_for_expired')) || session('is_change_for_expired') == false)
@@ -41,7 +41,7 @@
                                     </form>
                                 </div>
                     </div>
-                    <div class="card-body px-3 pt-0 overflow-auto">
+                    <div class="card-body px-2 pt-0 overflow-auto">
                         <table class="table table-striped task-table">
                             <thead>
                                 @can('isAdmin')

--- a/resources/views/task/index.blade.php
+++ b/resources/views/task/index.blade.php
@@ -27,19 +27,19 @@
                 </div>
                     <div class="card-body px-2 py-0 overflow-auto text-right">
                         <div class="mx-2">
-                                    <form action="{{ route('task.index') }}" method="GET">
-                                        @if(is_null(session('is_change_for_expired')) || session('is_change_for_expired') == false)
-                                        <input type="hidden" name="expired" value="expired">
-                                        <button class="btn btn-danger text-nowrap px-3 mx-1">
-                                            <i class="fa-solid fa-eye-slash"></i> 期限切れタスクに切替
-                                        @else
-                                        <input type="hidden" name="active" value="active">
-                                        <button class="btn btn-primary text-nowrap px-3 mx-1">
-                                            <i class="fa-solid fa-eye"></i> 有効なタスクに切替
-                                        @endif
-                                        </button>
-                                    </form>
-                                </div>
+                            <form action="{{ route('task.index') }}" method="GET">
+                                @if(is_null(session('is_change_for_expired')) || session('is_change_for_expired') == false)
+                                <input type="hidden" name="expired" value="expired">
+                                <button class="btn btn-danger text-nowrap px-3 mx-1">
+                                    <i class="fa-solid fa-eye-slash"></i> 期限切れタスクに切替
+                                @else
+                                <input type="hidden" name="active" value="active">
+                                <button class="btn btn-primary text-nowrap px-3 mx-1">
+                                    <i class="fa-solid fa-eye"></i> 有効なタスクに切替
+                                @endif
+                                </button>
+                            </form>
+                        </div>
                     </div>
                     <div class="card-body px-2 pt-0 overflow-auto">
                         <table class="table table-striped task-table">

--- a/resources/views/task/index.blade.php
+++ b/resources/views/task/index.blade.php
@@ -25,24 +25,43 @@
                         </div>
                     </form>
                 </div>
-                <div class="card border rounded">
-                    <div class="card-body pr-3 pl-3 overflow-auto">
+                    <div class="card-body px-3 py-0 overflow-auto text-right">
+                        <div class="mx-2">
+                                    <form action="{{ route('task.index') }}" method="GET">
+                                        @if(is_null(session('is_change_for_expired')) || session('is_change_for_expired') == false)
+                                        <input type="hidden" name="expired" value="expired">
+                                        <button class="btn btn-danger text-nowrap px-3 mx-1">
+                                            <i class="fa-solid fa-eye-slash"></i> 期限切れタスクに切替
+                                        @else
+                                        <input type="hidden" name="active" value="active">
+                                        <button class="btn btn-primary text-nowrap px-3 mx-1">
+                                            <i class="fa-solid fa-eye"></i> 有効なタスクに切替
+                                        @endif
+                                        </button>
+                                    </form>
+                                </div>
+                    </div>
+                    <div class="card-body px-3 pt-0 overflow-auto">
                         <table class="table table-striped task-table">
                             <thead>
                                 @can('isAdmin')
                                 <th class="border-top-0 col-2 text-nowrap text-center">画像</th>
-                                <th class="border-top-0 col-3 text-nowrap text-center">タスク名</th>
-                                <th class="border-top-0 col-2 text-nowrap text-center">ユーザー名</th>
-                                <th class="border-top-0 col-1 text-nowrap text-center">ステータス</th>
-                                <th class="border-top-0 col-3 text-nowrap text-center">期限</th>
-                                <th class="border-top-0 col-1" colspan="2">&nbsp;</th>
+                                <th class="border-top-0 col-3 text-nowrap text-center">@sortablelink('name', 'タスク名')</th>
+                                <th class="border-top-0 col-2 text-nowrap text-center">@sortablelink('user_id', 'ユーザー')</th>
+                                <th class="border-top-0 col-1 text-nowrap text-center">@sortablelink('satus', 'ステータス')</th>
+                                <th class="border-top-0 col-3 text-nowrap text-center">@sortablelink('expired_at', '期限')</th>
                                 @else
                                 <th class="border-top-0 col-1 text-nowrap text-center">画像</th>
-                                <th class="border-top-0 col-4 text-nowrap text-center">タスク名</th>
-                                <th class="border-top-0 col-1 text-nowrap text-center">ステータス</th>
-                                <th class="border-top-0 col-4 text-nowrap text-center">期限</th>
-                                <th class="border-top-0 col-1" colspan="2">&nbsp;</th>
+                                <th class="border-top-0 col-4 text-nowrap text-center">@sortablelink('name', 'タスク名')</th>
+                                <th class="border-top-0 col-1 text-nowrap text-center">@sortablelink('satus', 'ステータス')</th>
+                                <th class="border-top-0 col-4 text-nowrap text-center">@sortablelink('expired_at', '期限')</th>
                                 @endcan
+                                <th class="border-top-0 col-1">&nbsp;</th>
+                                <th class="border-top-0 col-1">
+                                    <a href="{{ route('task.export_csv') }}" class="btn btn-primary text-nowrap" download>
+                                        <i class="fa-solid fa-file-export"></i>出力
+                                    </a>
+                                </th>
                                 <th class="border-top-0 col-1">
                                     <a href="{{ route('task.create') }}" class="btn btn-primary text-nowrap">
                                         <i class="fa-solid fa-plus"></i>作成
@@ -56,7 +75,7 @@
                                         @can('isAdmin')
                                         <td>&nbsp;</td>
                                         @endcan
-                                        <td colspan="4">&nbsp;</td>
+                                        <td colspan="5">&nbsp;</td>
                                     </tr>
                                 @else
                                 @foreach($tasks as $task)
@@ -79,7 +98,11 @@
                                             <div>{{ \App\Enums\TaskStatus::getDescription($task->status) }}</div>
                                         </td>
                                         <td class="table-text py-0 align-middle text-dark text-nowrap text-center">
+                                            @if(is_null(session('is_change_for_expired')) || session('is_change_for_expired') == false)
                                             <div>{{ \Carbon\Carbon::parse($task->expired_at)->format('Y年m月d日 H:i') }}</div>
+                                            @else
+                                            <div class="text-danger">{{ \Carbon\Carbon::parse($task->expired_at)->format('Y年m月d日 H:i') }}</div>
+                                            @endif
                                         </td>
                                         <td class="py-0 align-middle text-center">
                                             <a href="{{ route('task.show',$task->id) }}" class="btn btn-primary text-nowrap">
@@ -101,6 +124,19 @@
                                 @endif
                             </tbody>
                         </table>
+                        <div class="container-fluid">
+                            <div class="row justify-content-md-center">
+                                <div class="align-center col">
+                                    &nbsp;
+                                </div>
+                                <div class="align-center col">
+                                    {{ $tasks->links('pagination::bootstrap-4') }}
+                                </div>
+                                <div class="align-center col">
+                                    &nbsp;
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,7 @@ Route::group(['middleware' => ['auth.user', 'weather']], function () {
         Route::patch('/update/{task}', [TaskController::class, 'update'])->name('task.update');
         Route::delete('/{task}', [TaskController::class, 'destroy'])->name('task.destroy');
         Route::post('/store/csv', [TaskController::class, 'storeCsv'])->name('task.store_csv');
+        Route::get('/export/csv', [TaskController::class, 'exportCsv'])->name('task.export_csv');
     });
     Route::prefix('/task_comment')->group(function () {
         Route::post('/store', [TaskCommentController::class, 'store'])->name('task_comment.store');


### PR DESCRIPTION
研修課題で作成したタスク管理サイトにユーザーのパスワードを変更する機能を追加しました。

変更した箇所

- タスク一覧画面にタスクの期限で切り替えを行うボタンを追加(task.index.blade.php)
- タスク一覧画面にタスクをCSV出力するボタンを追加(task.index.blade.php)
- タスク一覧画面にページネーション(10項目ずつ)を追加(task.index.blade.php)
- タスク一覧画面にソート機能を追加(task.index.blade.php)

タスク一覧画面(task.index.blade.php)
<img width="1440" alt="スクリーンショット 2024-02-06 19 48 50" src="https://github.com/TanakaTanakaKK/quickstart-laravel/assets/153486570/08a732f6-5188-4900-8cec-8953dc702e7a">
タスク一覧画面下部分(task.index.blade.php)
<img width="1440" alt="スクリーンショット 2024-02-06 19 49 14" src="https://github.com/TanakaTanakaKK/quickstart-laravel/assets/153486570/f424dded-0bb1-4462-bdd7-9a4fb825f500">
タスク一覧画面期限切れタスクに切替後(task.index.blade.php)
<img width="1440" alt="スクリーンショット 2024-02-06 19 50 44" src="https://github.com/TanakaTanakaKK/quickstart-laravel/assets/153486570/bd0624bf-5b36-402a-8614-dc36d4b5558b">
タスク一覧画面CSV出力ボタンクリック後(task.index.blade.php)
<img width="1440" alt="スクリーンショット 2024-02-06 19 52 07" src="https://github.com/TanakaTanakaKK/quickstart-laravel/assets/153486570/18a19c2f-d2e6-4471-910d-3295f594d54b">
出力したCSV
<img width="1440" alt="スクリーンショット 2024-02-06 19 52 30" src="https://github.com/TanakaTanakaKK/quickstart-laravel/assets/153486570/d8a3cde8-d9cb-48dd-8e93-cba979ae2897">
